### PR TITLE
Wandb initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ nohup.out
 *.pkl
 visual_llama.ipynb
 visual_llama.py
+wandb/
 
 # scripts for experiments in progress
 my_*.sh

--- a/elk/__main__.py
+++ b/elk/__main__.py
@@ -8,7 +8,7 @@ from elk.evaluation.evaluate import Eval
 from elk.plotting.command import Plot
 from elk.training.sweep import Sweep
 from elk.training.train import Elicit
-from elk.utils.wandb_utils import wandb_init_helper
+from elk.utils.wandb_init import wandb_init_helper
 
 
 @dataclass

--- a/elk/__main__.py
+++ b/elk/__main__.py
@@ -9,6 +9,8 @@ from elk.plotting.command import Plot
 from elk.training.sweep import Sweep
 from elk.training.train import Elicit
 
+from .wandb_utils import wandb_init_helper
+
 
 @dataclass
 class Command:
@@ -24,6 +26,7 @@ def run():
     parser = ArgumentParser(add_help=False)
     parser.add_arguments(Command, dest="run")
     args = parser.parse_args()
+    wandb_init_helper(args.run.command, project_name="elk_test_experiment2")
     run: Command = args.run
     run.execute()
 

--- a/elk/__main__.py
+++ b/elk/__main__.py
@@ -25,7 +25,7 @@ def run():
     parser = ArgumentParser(add_help=False)
     parser.add_arguments(Command, dest="run")
     args = parser.parse_args()
-    wandb_init_helper(args.run.command, project_name="elk_test_experiment2")
+    wandb_init_helper(args.run.command)
     run: Command = args.run
     run.execute()
 

--- a/elk/__main__.py
+++ b/elk/__main__.py
@@ -8,8 +8,7 @@ from elk.evaluation.evaluate import Eval
 from elk.plotting.command import Plot
 from elk.training.sweep import Sweep
 from elk.training.train import Elicit
-
-from .wandb_utils import wandb_init_helper
+from elk.utils.wandb_utils import wandb_init_helper
 
 
 @dataclass

--- a/elk/plotting/command.py
+++ b/elk/plotting/command.py
@@ -25,7 +25,9 @@ class Plot:
     wandb_tracking: bool = True
     """Whether to add plots to the sweep run in wandb"""
 
-    # TODO: implement!
+    wandb_project_name: str | None = None
+    """The name of the wandb project to track the run in"""
+
     def execute(self):
         root_dir = sweeps_dir()
 

--- a/elk/plotting/command.py
+++ b/elk/plotting/command.py
@@ -22,6 +22,10 @@ class Plot:
     overwrite: bool = False
     """Whether to overwrite existing plots."""
 
+    wandb_tracking: bool = True
+    """Whether to add plots to the sweep run in wandb"""
+
+    # TODO: implement!
     def execute(self):
         root_dir = sweeps_dir()
 

--- a/elk/plotting/command.py
+++ b/elk/plotting/command.py
@@ -25,7 +25,7 @@ class Plot:
     wandb_tracking: bool = True
     """Whether to add plots to the sweep run in wandb"""
 
-    wandb_project_name: str | None = None
+    wandb_project_name: str | None = "default_project"
     """The name of the wandb project to track the run in"""
 
     def execute(self):

--- a/elk/plotting/visualize.py
+++ b/elk/plotting/visualize.py
@@ -265,7 +265,7 @@ class ModelVisualization:
         """
         if wandb.run is None:
             entity_name = os.getenv("WANDB_ENTITY")
-            assert entity_name is not None, "Please set a WANDB_ENTITY env variable"
+            assert entity_name is not None, "Please set a WANDB_ENTITY env variable."
             project_name, run_id = find_run_details(
                 entity_name=entity_name, run_name=sweep.name
             )

--- a/elk/plotting/visualize.py
+++ b/elk/plotting/visualize.py
@@ -263,11 +263,10 @@ class ModelVisualization:
             prompt_ensembling: The prompt_ensembling option to consider.
         """
         if wandb.run is None:
-            run_details = find_run_details(
+            project_name, run_id = find_run_details(
                 entity_name="da-zealots", run_name=sweep.name
             )
-            if run_details is not None:
-                project_name, run_id = run_details[0], run_details[1]
+            if run_id is not None:
                 wandb.init(
                     entity="da-zealots", project=project_name, id=run_id, resume="allow"
                 )

--- a/elk/plotting/visualize.py
+++ b/elk/plotting/visualize.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
@@ -13,8 +14,6 @@ from rich.table import Table
 import wandb
 from elk.utils.types import PromptEnsembling
 from elk.utils.wandb_utils import find_run_details
-
-ENTITY_NAME = "da-zealots"  # temporary variable
 
 
 @dataclass
@@ -265,12 +264,14 @@ class ModelVisualization:
             prompt_ensembling: The prompt_ensembling option to consider.
         """
         if wandb.run is None:
+            entity_name = os.getenv("WANDB_ENTITY")
+            assert entity_name is not None, "Please set a WANDB_ENTITY env variable"
             project_name, run_id = find_run_details(
-                entity_name=ENTITY_NAME, run_name=sweep.name
+                entity_name=entity_name, run_name=sweep.name
             )
             if run_id is not None:
                 wandb.init(
-                    entity=ENTITY_NAME, project=project_name, id=run_id, resume="allow"
+                    entity=entity_name, project=project_name, id=run_id, resume="allow"
                 )
             else:
                 wandb.init(mode="disabled")

--- a/elk/plotting/visualize.py
+++ b/elk/plotting/visualize.py
@@ -14,6 +14,8 @@ import wandb
 from elk.utils.types import PromptEnsembling
 from elk.utils.wandb_utils import find_run_details
 
+ENTITY_NAME = "da-zealots"  # temporary variable
+
 
 @dataclass
 class SweepByDsMultiplot:
@@ -264,11 +266,11 @@ class ModelVisualization:
         """
         if wandb.run is None:
             project_name, run_id = find_run_details(
-                entity_name="da-zealots", run_name=sweep.name
+                entity_name=ENTITY_NAME, run_name=sweep.name
             )
             if run_id is not None:
                 wandb.init(
-                    entity="da-zealots", project=project_name, id=run_id, resume="allow"
+                    entity=ENTITY_NAME, project=project_name, id=run_id, resume="allow"
                 )
             else:
                 wandb.init(mode="disabled")

--- a/elk/run.py
+++ b/elk/run.py
@@ -33,6 +33,7 @@ from .utils import (
     select_usable_devices,
 )
 from .utils.types import PromptEnsembling
+from .utils.wandb_utils import wandb_save_probes
 
 PROMPT_ENSEMBLING = "prompt_ensembling"
 
@@ -167,6 +168,7 @@ class Run(ABC, Serializable):
             probe_per_prompt=self.probe_per_prompt,
         )
         self.apply_to_layers(func=func, num_devices=num_devices)
+        wandb_save_probes(self.out_dir)
 
     @abstractmethod
     def apply_to_layer(

--- a/elk/run.py
+++ b/elk/run.py
@@ -115,7 +115,7 @@ class Run(ABC, Serializable):
     num_gpus: int = -1
     disable_cache: bool = field(default=False, to_dict=False)
     wandb_tracking: bool = field(default=True, to_dict=False)
-    wandb_project_name: str | None = field(default=None, to_dict=False)
+    wandb_project_name: str | None = field(default="default_project", to_dict=False)
 
     def execute(
         self,

--- a/elk/run.py
+++ b/elk/run.py
@@ -33,7 +33,7 @@ from .utils import (
     select_usable_devices,
 )
 from .utils.types import PromptEnsembling
-from .utils.wandb_utils import wandb_save_probes
+from .utils.wandb_utils import wandb_rename_run
 
 PROMPT_ENSEMBLING = "prompt_ensembling"
 
@@ -140,7 +140,8 @@ class Run(ABC, Serializable):
             self.out_dir = memorably_named_dir(root)
 
         # Set wandb run name
-        wandb.run.name = self.out_dir.__str__().split("/")[-1]
+        wandb.run.name = wandb_rename_run(self.out_dir)
+
         # Print the output directory in bold with escape codes
         print(f"Output directory at \033[1m{self.out_dir}\033[0m")
         self.out_dir.mkdir(parents=True, exist_ok=True)
@@ -168,7 +169,6 @@ class Run(ABC, Serializable):
             probe_per_prompt=self.probe_per_prompt,
         )
         self.apply_to_layers(func=func, num_devices=num_devices)
-        wandb_save_probes(self.out_dir)
 
     @abstractmethod
     def apply_to_layer(

--- a/elk/run.py
+++ b/elk/run.py
@@ -115,6 +115,7 @@ class Run(ABC, Serializable):
     num_gpus: int = -1
     disable_cache: bool = field(default=False, to_dict=False)
     wandb_tracking: bool = field(default=True, to_dict=False)
+    wandb_project_name: str | None = field(default=None, to_dict=False)
 
     def execute(
         self,

--- a/elk/run.py
+++ b/elk/run.py
@@ -146,6 +146,7 @@ class Run(ABC, Serializable):
         if wandb.run is None:
             wandb.init(mode="disabled")
         wandb.run.name = wandb_rename_run(self.out_dir)
+        wandb.run.save()
 
         # Print the output directory in bold with escape codes
         print(f"Output directory at \033[1m{self.out_dir}\033[0m")

--- a/elk/run.py
+++ b/elk/run.py
@@ -174,8 +174,9 @@ class Run(ABC, Serializable):
             probe_per_prompt=self.probe_per_prompt,
         )
         self.apply_to_layers(func=func, num_devices=num_devices)
-        wandb_save_probes_dir(self.out_dir, "lr_models")
-        wandb_save_probes_dir(self.out_dir, "reporters")
+        if self.__class__.__name__ != "Eval":  # hacky way
+            wandb_save_probes_dir(self.out_dir, "lr_models")
+            wandb_save_probes_dir(self.out_dir, "reporters")
 
     @abstractmethod
     def apply_to_layer(

--- a/elk/training/sweep.py
+++ b/elk/training/sweep.py
@@ -55,6 +55,9 @@ class Sweep:
     wandb_tracking: bool = True
     """Whether to track a wandb run"""
 
+    wandb_project_name: str | None = None
+    """The name of the wandb project to track the run in"""
+
     name: str | None = None
 
     # A bit of a hack to add all the command line arguments from Elicit

--- a/elk/training/sweep.py
+++ b/elk/training/sweep.py
@@ -8,6 +8,7 @@ from transformers import AutoConfig
 import wandb
 
 from ..files import memorably_named_dir, sweeps_dir
+from ..plotting.visualize import visualize_sweep
 from ..training.eigen_reporter import EigenFitterConfig
 from ..utils import colorize
 from ..utils.constants import BURNS_DATASETS
@@ -170,6 +171,4 @@ class Sweep:
                                     continue
         wandb.run.name = sweep_dir.__str__().split("/")[-1]
         if self.visualize:
-            from ..plotting.visualize import visualize_sweep
-
             visualize_sweep(sweep_dir)

--- a/elk/training/sweep.py
+++ b/elk/training/sweep.py
@@ -8,7 +8,6 @@ from transformers import AutoConfig
 import wandb
 
 from ..files import memorably_named_dir, sweeps_dir
-from ..plotting.visualize import visualize_sweep
 from ..training.eigen_reporter import EigenFitterConfig
 from ..utils import colorize
 from ..utils.constants import BURNS_DATASETS
@@ -171,4 +170,6 @@ class Sweep:
                                     continue
         wandb.run.name = sweep_dir.__str__().split("/")[-1]
         if self.visualize:
+            from ..plotting.visualize import visualize_sweep
+
             visualize_sweep(sweep_dir)

--- a/elk/training/sweep.py
+++ b/elk/training/sweep.py
@@ -55,7 +55,7 @@ class Sweep:
     wandb_tracking: bool = True
     """Whether to track a wandb run"""
 
-    wandb_project_name: str | None = None
+    wandb_project_name: str | None = "default_project"
     """The name of the wandb project to track the run in"""
 
     name: str | None = None

--- a/elk/training/sweep.py
+++ b/elk/training/sweep.py
@@ -5,6 +5,8 @@ import torch
 from datasets import get_dataset_config_info
 from transformers import AutoConfig
 
+import wandb
+
 from ..files import memorably_named_dir, sweeps_dir
 from ..plotting.visualize import visualize_sweep
 from ..training.eigen_reporter import EigenFitterConfig
@@ -49,6 +51,9 @@ class Sweep:
 
     visualize: bool = False
     """Whether to generate visualizations of the results of the sweep."""
+
+    wandb_tracking: bool = True
+    """Whether to track a wandb run"""
 
     name: str | None = None
 
@@ -164,6 +169,6 @@ class Sweep:
                                     print(e)
                                     print(asdict(eval))
                                     continue
-
+        wandb.run.name = sweep_dir.__str__().split("/")[-1]
         if self.visualize:
             visualize_sweep(sweep_dir)

--- a/elk/training/train.py
+++ b/elk/training/train.py
@@ -18,6 +18,7 @@ from ..metrics.eval import LayerOutput
 from ..run import LayerApplied, PreparedData, Run
 from ..training.supervised import train_supervised
 from ..utils.types import PromptEnsembling
+from ..utils.wandb_utils import wandb_save_probe
 from . import Classifier
 from .ccs_reporter import CcsConfig, CcsReporter
 from .common import FitterConfig
@@ -211,7 +212,7 @@ class Elicit(Run):
         # TODO have to change this
         out_dir.mkdir(parents=True, exist_ok=True)
         torch.save(reporter, out_dir / f"layer_{layer}.pt")
-
+        wandb_save_probe(out_dir / f"layer_{layer}.pt", model_type="reporters")
         return ReporterWithInfo(reporter, train_loss, prompt_index)
 
     def train_lr_model(self, train_dict, device, layer, out_dir) -> list[Classifier]:
@@ -225,6 +226,7 @@ class Elicit(Run):
             out_dir.mkdir(parents=True, exist_ok=True)
             with open(out_dir / f"layer_{layer}.pt", "wb") as file:
                 torch.save(lr_models, file)
+            wandb_save_probe(out_dir / f"layer_{layer}.pt", model_type="lr_models")
         else:
             lr_models = []
 

--- a/elk/training/train.py
+++ b/elk/training/train.py
@@ -178,6 +178,8 @@ class Elicit(Run):
         if isinstance(self.net, CcsConfig):
             assert len(train_dict) == 1, "CCS only supports single-task training"
             reporter = CcsReporter(self.net, d, device=device, num_variants=v)
+            if wandb.run is None:
+                wandb.init(mode="disabled")
             wandb.watch(reporter)
             train_loss = reporter.fit(first_train_h)
             labels = repeat(to_one_hot(train_gt, k), "n k -> n v k", v=v)

--- a/elk/training/train.py
+++ b/elk/training/train.py
@@ -18,7 +18,6 @@ from ..metrics.eval import LayerOutput
 from ..run import LayerApplied, PreparedData, Run
 from ..training.supervised import train_supervised
 from ..utils.types import PromptEnsembling
-from ..utils.wandb_utils import wandb_save_probe
 from . import Classifier
 from .ccs_reporter import CcsConfig, CcsReporter
 from .common import FitterConfig
@@ -214,7 +213,7 @@ class Elicit(Run):
         # TODO have to change this
         out_dir.mkdir(parents=True, exist_ok=True)
         torch.save(reporter, out_dir / f"layer_{layer}.pt")
-        wandb_save_probe(out_dir / f"layer_{layer}.pt", model_type="reporters")
+
         return ReporterWithInfo(reporter, train_loss, prompt_index)
 
     def train_lr_model(self, train_dict, device, layer, out_dir) -> list[Classifier]:
@@ -228,7 +227,6 @@ class Elicit(Run):
             out_dir.mkdir(parents=True, exist_ok=True)
             with open(out_dir / f"layer_{layer}.pt", "wb") as file:
                 torch.save(lr_models, file)
-            wandb_save_probe(out_dir / f"layer_{layer}.pt", model_type="lr_models")
         else:
             lr_models = []
 

--- a/elk/utils/wandb_init.py
+++ b/elk/utils/wandb_init.py
@@ -1,5 +1,4 @@
 from argparse import Namespace
-from copy import deepcopy
 
 import wandb
 from elk.evaluation.evaluate import Eval
@@ -7,16 +6,18 @@ from elk.training.sweep import Sweep
 from elk.training.train import Elicit
 
 
-def wandb_init_helper(
-    args: Namespace, project_name: str = "elk_test_experiment"
-) -> None:
+def wandb_init_helper(args: Namespace) -> None:
     """
     Serializes args so they can be logged in wandb
     and starts a run according to the command type.
     """
+    project_name = args.wandb_project_name
     if args.wandb_tracking:
+        if project_name is None:
+            project_name = "default_project"
+
         if isinstance(args, Eval):
-            args_serialized = deepcopy(args)
+            args_serialized = args.to_dict()
             args_serialized.out_dir = str(
                 args_serialized.out_dir
             )  # .as_posix method would break on windows

--- a/elk/utils/wandb_init.py
+++ b/elk/utils/wandb_init.py
@@ -1,3 +1,4 @@
+import os
 from argparse import Namespace
 
 import wandb
@@ -13,8 +14,13 @@ def wandb_init_helper(args: Namespace) -> None:
     """
     project_name = args.wandb_project_name
     if args.wandb_tracking:
+        # Get project name
         if project_name is None:
             project_name = "default_project"
+
+        # Get entity name
+        entity_name = os.getenv("WANDB_ENTITY")
+        assert entity_name is not None, "Please set a WANDB_ENTITY env variable"
 
         if isinstance(args, Eval):
             args_serialized = args.to_dict()
@@ -22,12 +28,19 @@ def wandb_init_helper(args: Namespace) -> None:
                 args_serialized.out_dir
             )  # .as_posix method would break on windows
             args_serialized.source = str(args_serialized.source)
-            wandb.init(project=project_name, config=args_serialized, job_type="eval")
+            wandb.init(
+                entity=entity_name,
+                project=project_name,
+                config=args_serialized,
+                job_type="eval",
+            )
         elif isinstance(args, Elicit):
-            wandb.init(project=project_name, config=args, job_type="train")
+            wandb.init(
+                entity=entity_name, project=project_name, config=args, job_type="train"
+            )
         elif isinstance(args, Sweep):
             wandb.init(
-                project=project_name, config=args, job_type="sweep", group="Sweep1"
+                entity=entity_name, project=project_name, config=args, job_type="sweep"
             )
     else:
         wandb.init(mode="disabled")

--- a/elk/utils/wandb_init.py
+++ b/elk/utils/wandb_init.py
@@ -1,0 +1,32 @@
+from argparse import Namespace
+from copy import deepcopy
+
+import wandb
+from elk.evaluation.evaluate import Eval
+from elk.training.sweep import Sweep
+from elk.training.train import Elicit
+
+
+def wandb_init_helper(
+    args: Namespace, project_name: str = "elk_test_experiment"
+) -> None:
+    """
+    Serializes args so they can be logged in wandb
+    and starts a run according to the command type.
+    """
+    if args.wandb_tracking:
+        if isinstance(args, Eval):
+            args_serialized = deepcopy(args)
+            args_serialized.out_dir = str(
+                args_serialized.out_dir
+            )  # .as_posix method would break on windows
+            args_serialized.source = str(args_serialized.source)
+            wandb.init(project=project_name, config=args_serialized, job_type="eval")
+        elif isinstance(args, Elicit):
+            wandb.init(project=project_name, config=args, job_type="train")
+        elif isinstance(args, Sweep):
+            wandb.init(
+                project=project_name, config=args, job_type="sweep", group="Sweep1"
+            )
+    else:
+        wandb.init(mode="disabled")

--- a/elk/utils/wandb_init.py
+++ b/elk/utils/wandb_init.py
@@ -20,10 +20,10 @@ def wandb_init_helper(args: Namespace) -> None:
 
         if isinstance(args, Eval):
             args_serialized = args.to_dict()
-            args_serialized.out_dir = str(
-                args_serialized.out_dir
+            args_serialized["out_dir"] = str(
+                args_serialized["out_dir"]
             )  # .as_posix method would break on windows
-            args_serialized.source = str(args_serialized.source)
+            args_serialized["source"] = str(args_serialized["source"])
             wandb.init(
                 entity=entity_name,
                 project=project_name,

--- a/elk/utils/wandb_init.py
+++ b/elk/utils/wandb_init.py
@@ -14,10 +14,6 @@ def wandb_init_helper(args: Namespace) -> None:
     """
     project_name = args.wandb_project_name
     if args.wandb_tracking:
-        # Get project name
-        if project_name is None:
-            project_name = "default_project"
-
         # Get entity name
         entity_name = os.getenv("WANDB_ENTITY")
         assert entity_name is not None, "Please set a WANDB_ENTITY env variable"

--- a/elk/utils/wandb_utils.py
+++ b/elk/utils/wandb_utils.py
@@ -1,5 +1,6 @@
 from argparse import Namespace
 from copy import deepcopy
+from typing import Optional
 
 import wandb
 from elk.evaluation.evaluate import Eval
@@ -30,3 +31,35 @@ def wandb_init_helper(
             )
     else:
         wandb.init(mode="disabled")
+
+
+def find_run_id_by_name(entity_name: str, run_name: str) -> Optional[str]:
+    """
+    Search through all projects of a given entity to find the run ID
+    corresponding to a given run name.
+    This requires run names to be always unique.
+
+    Args:
+    - entity_name (str): Name of the entity (user/team).
+    - run_name (str): Name of the run.
+
+    Returns:
+    - str: run_id if found, otherwise None.
+    """
+
+    # Set up wandb API
+    api = wandb.Api()
+
+    # Iterate over all projects of the entity
+    for project in api.projects(entity=entity_name):
+        project_name = project.name
+
+        # Search for the run by name in the current project
+        runs = api.runs(path=f"{entity_name}/{project_name}")
+
+        for run in runs:
+            if run.name == run_name:
+                return run.id
+
+    # If no run found with the given name, return None
+    return None

--- a/elk/utils/wandb_utils.py
+++ b/elk/utils/wandb_utils.py
@@ -44,8 +44,8 @@ def wandb_save_probe(probe_path: Path, model_type: str) -> None:
 
 def wandb_save_probes_dir(out_dir: Path, model_dir: str) -> None:
     if wandb.run is not None:
-        artifact_name = get_model_name(out_dir / model_dir)
-        print(f"Saving artifact with name {artifact_name}")
+        artifact_name = get_model_name(out_dir / model_dir) + "." + model_dir
+        print(f"Saving artifact with name {artifact_name} and type {model_dir}")
         artifact = wandb.Artifact(artifact_name, type=model_dir)
         artifact.add_dir(out_dir / model_dir)
         wandb.run.log_artifact(artifact)

--- a/elk/utils/wandb_utils.py
+++ b/elk/utils/wandb_utils.py
@@ -4,18 +4,14 @@ from typing import Optional, Tuple
 import wandb
 
 
-def find_run_details(entity_name: str, run_name: str) -> Optional[Tuple[str, str]]:
+def find_run_details(
+    entity_name: str, run_name: str
+) -> Tuple[Optional[str], Optional[str]]:
     """
     Search through all projects of a given entity to find the run ID
     corresponding to a given run name.
-    This requires run names to be always unique.
-
-    Args:
-    - entity_name (str): Name of the entity (user/team).
-    - run_name (str): Name of the run.
-
-    Returns:
-    - str: run_id if found, otherwise None.
+    This requires run names to be ALWAYS unique,
+    which essentially requires all the experiments be run on the same machine.
     """
 
     # Set up wandb API
@@ -33,7 +29,7 @@ def find_run_details(entity_name: str, run_name: str) -> Optional[Tuple[str, str
                 return project_name, run.id
 
     # If no run found with the given name, return None
-    return None
+    return None, None
 
 
 def wandb_save_probes(out_dir: Path) -> None:

--- a/elk/utils/wandb_utils.py
+++ b/elk/utils/wandb_utils.py
@@ -1,6 +1,6 @@
 from argparse import Namespace
 from copy import deepcopy
-from typing import Optional
+from typing import Optional, Tuple
 
 import wandb
 from elk.evaluation.evaluate import Eval
@@ -33,7 +33,7 @@ def wandb_init_helper(
         wandb.init(mode="disabled")
 
 
-def find_run_id_by_name(entity_name: str, run_name: str) -> Optional[str]:
+def find_run_details(entity_name: str, run_name: str) -> Optional[Tuple[str, str]]:
     """
     Search through all projects of a given entity to find the run ID
     corresponding to a given run name.
@@ -59,7 +59,7 @@ def find_run_id_by_name(entity_name: str, run_name: str) -> Optional[str]:
 
         for run in runs:
             if run.name == run_name:
-                return run.id
+                return project_name, run.id
 
     # If no run found with the given name, return None
     return None

--- a/elk/utils/wandb_utils.py
+++ b/elk/utils/wandb_utils.py
@@ -42,6 +42,15 @@ def wandb_save_probe(probe_path: Path, model_type: str) -> None:
         wandb.run.log_artifact(artifact)
 
 
+def wandb_save_probes_dir(out_dir: Path, model_dir: str) -> None:
+    if wandb.run is not None:
+        artifact_name = get_model_name(out_dir / model_dir)
+        print(f"Saving artifact with name {artifact_name}")
+        artifact = wandb.Artifact(artifact_name, type=model_dir)
+        artifact.add_dir(out_dir / model_dir)
+        wandb.run.log_artifact(artifact)
+
+
 def wandb_rename_run(out_dir: Path) -> Optional[str]:
     "Highly hacky way to rename a run."
     str_out_dir = str(out_dir)

--- a/elk/wandb_utils.py
+++ b/elk/wandb_utils.py
@@ -1,0 +1,32 @@
+from argparse import Namespace
+from copy import deepcopy
+
+import wandb
+from elk.evaluation.evaluate import Eval
+from elk.training.sweep import Sweep
+from elk.training.train import Elicit
+
+
+def wandb_init_helper(
+    args: Namespace, project_name: str = "elk_test_experiment"
+) -> None:
+    """
+    Serializes args so they can be logged in wandb
+    and starts a run according to the command type.
+    """
+    if args.wandb_tracking:
+        if isinstance(args, Eval):
+            args_serialized = deepcopy(args)
+            args_serialized.out_dir = str(
+                args_serialized.out_dir
+            )  # .as_posix method would break on windows
+            args_serialized.source = str(args_serialized.source)
+            wandb.init(project=project_name, config=args_serialized, job_type="eval")
+        elif isinstance(args, Elicit):
+            wandb.init(project=project_name, config=args, job_type="train")
+        elif isinstance(args, Sweep):
+            wandb.init(
+                project=project_name, config=args, job_type="sweep", group="Sweep1"
+            )
+    else:
+        wandb.init(mode="disabled")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,8 @@ dependencies = [
     # For visualization of results
     "plotly==5.14.1",
     "kaleido==0.2.1",
-    "rich"
+    "rich",
+    "wandb==0.15.12"
 
 ]
 version = "0.1.1"


### PR DESCRIPTION
Initial implementation of wandb.ai experiment tracking.
You need to setup an env variable `WANDB_ENTITY` with the organization/WandB profile name

# Features
- Add `wandb_init_helper` fnc, which called in `__main__.py` to start WandB run
  - Add `wandb_tracking` (bool) and `wandb_project_name` (str with default) kwargs to most Commands.
- In Sweep and Elicitresult tables and (partial) training info are tracked by WandB
- In Plot, plots are added to previous WandB runs

## Issues
- Fix multi-gpu runs, it should be pretty straightforward
   - *Solution:* For now models will be stored after everything is trained.
- Agree on what should be tracked + naming conventions (so it's not pure chaos)
  - *Solution:*: Names of artifacts are not as important as long as they can be easily accessed and reused
- Implement credentials
  - *Solution:*: For now env variables will be used for wandb config. 